### PR TITLE
Remove react-map-gl peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "Victor Powell",
   "license": "MIT",
   "peerDependencies": {
-    "react-map-gl": "^0.6.0",
     "immutable": "^3.7.5",
     "r-dom": "^2.0.0",
     "react": "^0.14.0",


### PR DESCRIPTION
The react-map-gl peerDependency causes problems when using the new 1.0.0-beta version of react-map-gl.

As far as I can tell the peerDependency serves no real purpose. This module does not actually depend on react-map-gl, and can be used without it, e.g. with other base maps where lat and lng are available. So I propose to remove it completely.
