### PR TITLE
Remove r-dom

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -62,7 +62,7 @@ var App = React.createClass({
     return React.createElement(MapGL, assign({}, this.state.viewport, {
       onChangeViewport: this._onChangeViewport,
       mapStyle: this.state.mapStyle
-    }), [
+    }),
       React.createElement(HeatmapOverlay, assign({}, this.state.viewport, {
         locations: locations,
         // Semantic zoom
@@ -75,7 +75,7 @@ var App = React.createClass({
         //   return 30 * Math.pow(2, this.state.viewport.zoom - 0);
         // }
       }))
-    ]);
+    );
   }
 });
 

--- a/example/main.js
+++ b/example/main.js
@@ -5,7 +5,6 @@ var window = require('global/window');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var Immutable = require('immutable');
-var r = require('r-dom');
 var MapGL = require('react-map-gl');
 var HeatmapOverlay = require('../');
 var assign = require('object-assign');
@@ -60,11 +59,11 @@ var App = React.createClass({
   },
 
   render: function render() {
-    return r(MapGL, assign({}, this.state.viewport, {
+    return React.createElement(MapGL, assign({}, this.state.viewport, {
       onChangeViewport: this._onChangeViewport,
       mapStyle: this.state.mapStyle
     }), [
-      r(HeatmapOverlay, assign({}, this.state.viewport, {
+      React.createElement(HeatmapOverlay, assign({}, this.state.viewport, {
         locations: locations,
         // Semantic zoom
         sizeAccessor: function sizeAccessor() {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var React = require('react');
 var Immutable = require('immutable');
 var window = require('global/window');
 var document = require('global/document');
-var r = require('r-dom');
 var WebGLHeatmap = require('webgl-heatmap');
 var ViewportMercator = require('viewport-mercator-project');
 var viridis = require('scale-color-perceptual/hex/viridis.json');
@@ -122,7 +121,7 @@ module.exports = React.createClass({
 
   render: function render() {
     var pixelRatio = window.devicePixelRatio || 1;
-    return r.canvas({
+    return React.createElement('canvas', {
       ref: 'overlay',
       width: this.props.width * pixelRatio,
       height: this.props.height * pixelRatio,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "license": "MIT",
   "peerDependencies": {
     "immutable": "^3.7.5",
-    "r-dom": "^2.0.0",
     "react": "0.14.x - 15.x",
     "react-dom": "0.14.x - 15.x"
   },
@@ -44,7 +43,6 @@
     "bistre": "^1.0.1",
     "budo": "^6.0.1",
     "immutable": "^3.7.5",
-    "r-dom": "^2.1.0",
     "raster-tile-style": "^1.0.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",


### PR DESCRIPTION
react-map-gl was bumped to version 1.0.0 13 days ago and they remove r-dom, we either have to remove r-dom from peer-dependencies or remove it entirely.
