### PR TITLE
remove react-map-gl hard dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "example-cities": "0.0.0",
     "global": "^4.3.0",
     "object-assign": "^4.0.1",
-    "react-map-gl": "^0.6.9",
     "scale-color-perceptual": "^1.1.2",
     "viewport-mercator-project": "^2.0.1",
     "webgl-heatmap": "^0.2.0"


### PR DESCRIPTION
this module doesn't rely on react-map-gl to run, yet it had a dependency on a really old version. it already exists in devDependencies since it is used for the demos, but no reason for it to be in production deps. was causing a versioning conflict + extra downloads not needed.
