### PR TITLE
Support React 16

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var React = require('react');
-var PropTypes = require('prop-types')
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var Immutable = require('immutable');
 var window = require('global/window');
 var document = require('global/document');
@@ -10,7 +11,7 @@ var WebGLHeatmap = require('webgl-heatmap');
 var ViewportMercator = require('viewport-mercator-project');
 var viridis = require('scale-color-perceptual/hex/viridis.json');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   displayName: 'HeatmapOverlay',
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types')
 var Immutable = require('immutable');
 var window = require('global/window');
 var document = require('global/document');
@@ -14,19 +15,19 @@ module.exports = React.createClass({
   displayName: 'HeatmapOverlay',
 
   propTypes: {
-    width: React.PropTypes.number.isRequired,
-    height: React.PropTypes.number.isRequired,
-    longitude: React.PropTypes.number.isRequired,
-    latitude: React.PropTypes.number.isRequired,
-    zoom: React.PropTypes.number.isRequired,
-    locations: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.instanceOf(Immutable.List)
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
+    latitude: PropTypes.number.isRequired,
+    zoom: PropTypes.number.isRequired,
+    locations: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.instanceOf(Immutable.List)
     ]),
-    lngLatAccessor: React.PropTypes.func.isRequired,
-    intensityAccessor: React.PropTypes.func.isRequired,
-    sizeAccessor: React.PropTypes.func.isRequired,
-    gradientColors: React.PropTypes.instanceOf(Immutable.List).isRequired
+    lngLatAccessor: PropTypes.func.isRequired,
+    intensityAccessor: PropTypes.func.isRequired,
+    sizeAccessor: PropTypes.func.isRequired,
+    gradientColors: PropTypes.instanceOf(Immutable.List).isRequired
   },
 
   getDefaultProps: function getDefaultProps() {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "r-dom": "^2.0.0",
     "react": "0.14.x - 16.x",
     "react-dom": "0.14.x - 16.x",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "create-react-class": "^15.6.0"
   },
   "dependencies": {
     "example-cities": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "immutable": "^3.7.5",
     "r-dom": "^2.0.0",
     "react": "0.14.x - 16.x",
-    "react-dom": "0.14.x - 16.x",
-    "prop-types": "^15.6.0",
-    "create-react-class": "^15.6.0"
+    "react-dom": "0.14.x - 16.x"
   },
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "example-cities": "0.0.0",
     "global": "^4.3.0",
     "object-assign": "^4.0.1",
+    "prop-types": "^15.6.0",
     "scale-color-perceptual": "^1.1.2",
     "viewport-mercator-project": "^2.0.1",
     "webgl-heatmap": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   "peerDependencies": {
     "immutable": "^3.7.5",
     "r-dom": "^2.0.0",
-    "react": "0.14.x - 15.x",
-    "react-dom": "0.14.x - 15.x"
+    "react": "0.14.x - 16.x",
+    "react-dom": "0.14.x - 16.x",
+    "prop-types": "^15.6.0"
   },
   "dependencies": {
     "example-cities": "0.0.0",


### PR DESCRIPTION
From [the React 16 announcement](https://reactjs.org/blog/2017/09/26/react-v16.0.html#packaging)

> The deprecations introduced in 15.x have been removed from the core package. `React.createClass` is now available as `create-react-class`, `React.PropTypes` as `prop-types` ...

  * Replaced `React.PropTypes` and `React.createClass` with their npm packages
  * Updated `react` and `react-dom` versions in `peerDependencies`
